### PR TITLE
FIx: textKeys array null check

### DIFF
--- a/04_ens_resolution/frontend/src/index.js
+++ b/04_ens_resolution/frontend/src/index.js
@@ -68,7 +68,9 @@ async function getENSMetadata(ensName) {
     for (let i = 0, x = domains.length; i < x; i++) {
         let domain = domains[i];
         if (domain.name === ensName) {
-            textKeys = domain.resolver.texts;
+            if (domain.resolver?.texts) {
+                textKeys.push(domain.resolver.texts);
+            }
             break;
         }
     }

--- a/05_nft_resolution/frontend/src/index.js
+++ b/05_nft_resolution/frontend/src/index.js
@@ -74,7 +74,9 @@ async function getENSMetadata(ensName) {
     for (let i = 0, x = domains.length; i < x; i++) {
         let domain = domains[i];
         if (domain.name === ensName) {
-            textKeys = domain.resolver.texts;
+            if (domain.resolver?.texts) {
+                textKeys.push(domain.resolver.texts);
+            }
             break;
         }
     }


### PR DESCRIPTION
Hey there! was playing a little bit with the repo and found some issue whenever trying to fetch my ENS data on the client side. 

Seems that something's breaking whenever calling the `getENSMetadata` function. 

![image](https://user-images.githubusercontent.com/23338712/167467589-51fff633-3857-4aca-a522-102dc1b930a9.png)


Dived a little bit and found out that the graph response is coming with the `texts` field as `null` (which I don't think its intended??), causing the array of textElements to be null as well, resulting in a `TypeError` later. 

![image](https://user-images.githubusercontent.com/23338712/167467622-9f43f788-15c1-42f8-a7ba-8e357d0fd871.png)


Did a quick change, adding a null check to prevent the array being a plain `null`, and also pushing the result to it (if there's).

![image](https://user-images.githubusercontent.com/23338712/167467646-8a465311-6d82-4a22-a459-251bc4257398.png)


Both changes were made on the `04_ens_resolution` and `05_nft_resolution` directories. 

Hope this helps, thanks! 